### PR TITLE
Removed unecessary threads dependency

### DIFF
--- a/.github/composites/install-xmipp4-core/action.yml
+++ b/.github/composites/install-xmipp4-core/action.yml
@@ -37,6 +37,7 @@ runs:
         options: |
           BUILD_TESTING=OFF
           CMAKE_BUILD_TYPE=Release
+          XMIPP4_CORE_BUILD_SPDLOG=ON
         run-build: true
         build-args: --config ${{ env.BUILD_TYPE }}
 

--- a/.github/composites/install-xmipp4-core/action.yml
+++ b/.github/composites/install-xmipp4-core/action.yml
@@ -37,7 +37,6 @@ runs:
         options: |
           BUILD_TESTING=OFF
           CMAKE_BUILD_TYPE=Release
-          XMIPP4_CORE_BUILD_SPDLOG=ON
         run-build: true
         build-args: --config ${{ env.BUILD_TYPE }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,11 +38,27 @@ jobs:
     strategy:
       matrix:
         os:
-        - windows-latest
+        - ubuntu-latest
         compiler: 
-        - {cc: cl, cxx: cl}
+        - {cc: gcc, cxx: g++}
+        - {cc: clang, cxx: clang++}
         mpi:
-        - intelmpi
+        - openmpi
+
+        # TODO mpich with Clang is not working. Revisit
+        include:
+        - os: ubuntu-latest
+          compiler: {cc: gcc, cxx: g++}
+          mpi: mpich
+        - os: macos-latest
+          compiler: {cc: clang, cxx: clang++}
+          mpi: openmpi
+        - os: macos-latest
+          compiler: {cc: clang, cxx: clang++}
+          mpi: mpich
+        - os: windows-latest
+          compiler: {cc: cl, cxx: cl}
+          mpi: intelmpi
   
     runs-on: ${{ matrix.os }}
     defaults:
@@ -61,14 +77,10 @@ jobs:
         id: install-xmipp4-core
         uses: ./.github/composites/install-xmipp4-core
         with:
-          ref: 1e60dda01c82be1bcd8298e30437576e69f70944
-
-      - name: Cat
-        if: runner.os == 'Windows'
-        run: cat "D:/a/xmipp4-communication-mpi/xmipp4-core/dist/lib/cmake/xmipp4-core/xmipp4-core-config.cmake"
+          ref: main
       
       - name: Configure and build with CMake
-        uses: threeal/cmake-action@main
+        uses: threeal/cmake-action@v2.0.0
         with:
           source-dir: ${{ github.workspace }}
           build-dir: "${{ github.workspace }}/build"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,27 +38,11 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-latest
+        - windows-latest
         compiler: 
-        - {cc: gcc, cxx: g++}
-        - {cc: clang, cxx: clang++}
+        - {cc: cl, cxx: cl}
         mpi:
-        - openmpi
-        
-        # TODO mpich with Clang is not working. Revisit
-        include:
-        - os: ubuntu-latest
-          compiler: {cc: gcc, cxx: g++}
-          mpi: mpich
-        - os: macos-latest
-          compiler: {cc: clang, cxx: clang++}
-          mpi: openmpi
-        - os: macos-latest
-          compiler: {cc: clang, cxx: clang++}
-          mpi: mpich
-        - os: windows-latest
-          compiler: {cc: cl, cxx: cl}
-          mpi: intelmpi
+        - intelmpi
   
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,7 +61,7 @@ jobs:
         id: install-xmipp4-core
         uses: ./.github/composites/install-xmipp4-core
         with:
-          ref: olz_config
+          ref: 1e60dda01c82be1bcd8298e30437576e69f70944
 
       - name: Cat
         if: runner.os == 'Windows'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Cat
         if: runner.os == 'Windows'
-        run: cat "D:/a/xmipp4-communication-mpi/xmipp4-core/dist/lib/cmake/xmipp4-core/xmipp4-core-config-version.cmake"
+        run: cat "D:/a/xmipp4-communication-mpi/xmipp4-core/dist/lib/cmake/xmipp4-core/xmipp4-core-config.cmake"
       
       - name: Configure and build with CMake
         uses: threeal/cmake-action@main

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -88,7 +88,7 @@ jobs:
           cxx-compiler: ${{ matrix.compiler.cxx }}
           options: |
             CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
-            xmipp4-core_DIR=${{ steps.install-xmipp4-core.outputs.xmipp4-core-root }}
+            xmipp4-core_ROOT=${{ steps.install-xmipp4-core.outputs.xmipp4-core-root }}
           run-build: true
           build-args: --config ${{ env.BUILD_TYPE }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -88,7 +88,7 @@ jobs:
           cxx-compiler: ${{ matrix.compiler.cxx }}
           options: |
             CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
-            xmipp4-core_ROOT=${{ steps.install-xmipp4-core.outputs.xmipp4-core-root }}
+            xmipp4-core_DIR=${{ steps.install-xmipp4-core.outputs.xmipp4-core-root }}
           run-build: true
           build-args: --config ${{ env.BUILD_TYPE }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,6 +78,10 @@ jobs:
         uses: ./.github/composites/install-xmipp4-core
         with:
           ref: main
+
+      - name: Cat
+        if: runner.os == 'Windows'
+        run: cat "D:/a/xmipp4-communication-mpi/xmipp4-core/dist/lib/cmake/xmipp4-core/xmipp4-core-config-version.cmake"
       
       - name: Configure and build with CMake
         uses: threeal/cmake-action@main

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,7 +77,7 @@ jobs:
         id: install-xmipp4-core
         uses: ./.github/composites/install-xmipp4-core
         with:
-          ref: main
+          ref: olz_config
 
       - name: Cat
         if: runner.os == 'Windows'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ endif()
 
 # Find dependencies
 find_package(MPI 3 COMPONENTS CXX REQUIRED)
-find_package(Threads REQUIRED)
 
 # Find all source and header files
 file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 
 # Find dependencies
 find_package(MPI 3 COMPONENTS CXX REQUIRED)
+find_package(Threads REQUIRED)
 
 # Find all source and header files
 file(


### PR DESCRIPTION
With the updated core CMake installation, this core's dependency does not need to be included in plugins as it is imported from the core package itself