### PR TITLE
Added dependabot updates for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # Group all non-major updates into a single Pull Request
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,26 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#              Martín Salinas Antón (ssalinasmartin@gmail.com)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 name: Build and Test
 
 on:
@@ -80,7 +57,7 @@ jobs:
           ref: main
       
       - name: Configure and build with CMake
-        uses: threeal/cmake-action@v2.0.0
+        uses: threeal/cmake-action@v2
         with:
           source-dir: ${{ github.workspace }}
           build-dir: "${{ github.workspace }}/build"


### PR DESCRIPTION
Also:
- Fixed cmake action to major symlink. It seems that, when you select vX in an external action version, it automatically points to the latest minor-patch version of that major. That makes the dependabot group for minor and patch tweak unnecessary, but it does not hurt keeping it just in case we need to specify a vX.Y.Z version for some reason (up for debate, we could also remove it).
- Removed lincese header for actions. I'd just keep it for the source code, as it is really verbose and really only makes sense for the project's source code, not for actions and/or tests.