### PR TITLE
Only available if world size is greater than one

### DIFF
--- a/src/communication/mpi/mpi_communicator_backend.cpp
+++ b/src/communication/mpi/mpi_communicator_backend.cpp
@@ -38,6 +38,11 @@ namespace xmipp4
 namespace communication
 {
 
+mpi_communicator_backend::mpi_communicator_backend()
+    : m_instance(mpi_instance::get())
+{
+}
+
 std::string mpi_communicator_backend::get_name() const noexcept
 {
     return "mpi";
@@ -53,7 +58,9 @@ version mpi_communicator_backend::get_version() const noexcept
 
 bool mpi_communicator_backend::is_available() const noexcept
 {
-    return true;
+    int size = 0;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    return size > 1;
 }
 
 backend_priority mpi_communicator_backend::get_priority() const noexcept

--- a/src/communication/mpi/mpi_communicator_backend.hpp
+++ b/src/communication/mpi/mpi_communicator_backend.hpp
@@ -28,6 +28,8 @@
  * 
  */
 
+#include "mpi_instance.hpp"
+
 #include <xmipp4/core/communication/communicator_backend.hpp>
 
 #include <memory>
@@ -45,11 +47,24 @@ class mpi_communicator_backend final
     : public communicator_backend
 {
 public:
+    mpi_communicator_backend();
+    mpi_communicator_backend(const mpi_communicator_backend &other) = default;
+    mpi_communicator_backend(mpi_communicator_backend &&other) = default;
+    ~mpi_communicator_backend() override = default;
+
+    mpi_communicator_backend&
+    operator=(const mpi_communicator_backend &other) = default;
+    mpi_communicator_backend&
+    operator=(mpi_communicator_backend &&other) = default;
+
     std::string get_name() const noexcept override;
     version get_version() const noexcept override;
     bool is_available() const noexcept override;
     backend_priority get_priority() const noexcept override;
     std::shared_ptr<communicator> get_world_communicator() const override;
+
+private:
+    std::shared_ptr<mpi_instance> m_instance;
 
 };
 

--- a/src/communication/mpi/mpi_instance.cpp
+++ b/src/communication/mpi/mpi_instance.cpp
@@ -37,7 +37,7 @@ namespace xmipp4
 namespace communication
 {
 
-std::unique_ptr<mpi_instance> mpi_instance::m_singleton;
+std::weak_ptr<mpi_instance> mpi_instance::m_singleton;
 
 mpi_instance::mpi_instance()
 {
@@ -49,15 +49,19 @@ mpi_instance::~mpi_instance()
     MPI_Finalize();
 }
 
-mpi_instance& mpi_instance::get()
+std::shared_ptr<mpi_instance> mpi_instance::get()
 {
-    if(!m_singleton)
+    auto result = m_singleton.lock();
+
+    if(!result)
     {
-        m_singleton = std::unique_ptr<mpi_instance>(new mpi_instance());
+        result.reset(new mpi_instance());
+        m_singleton = result;
     }
 
-    XMIPP4_ASSERT(m_singleton);
-    return *m_singleton;
+    XMIPP4_ASSERT(result);
+    return result;
+
 }
 
 } // namespace communication

--- a/src/communication/mpi/mpi_instance.hpp
+++ b/src/communication/mpi/mpi_instance.hpp
@@ -45,10 +45,10 @@ public:
     mpi_instance& operator=(const mpi_instance &other) = delete;
     mpi_instance& operator=(mpi_instance &&other) = delete;
 
-    static mpi_instance& get();
+    static std::shared_ptr<mpi_instance> get();
 
 private:
-    static std::unique_ptr<mpi_instance> m_singleton;
+    static std::weak_ptr<mpi_instance> m_singleton;
     
     mpi_instance();
 


### PR DESCRIPTION
If world size is 1 (only one process), it does not make sense to use MPI, as the dummy communicator in the core is much lighter and it provides the same functionality. Thus, when running in as a single process, MPI plugin marks itself as unavailable.