### PR TITLE
Lazily initializing MPI to avoid cluttering the interface registration

### DIFF
--- a/src/communication/mpi/mpi_communicator_backend.cpp
+++ b/src/communication/mpi/mpi_communicator_backend.cpp
@@ -31,6 +31,8 @@
 #include "mpi_instance.hpp"
 #include "mpi_communicator.hpp"
 
+#include <xmipp4/core/communication/communicator_manager.hpp>
+
 #include <mpi.h>
 
 namespace xmipp4 
@@ -79,6 +81,10 @@ mpi_communicator_backend::create_world_communicator() const
     return std::make_shared<mpi_communicator>(MPI_COMM_WORLD);
 }
 
+bool mpi_communicator_backend::register_at(communicator_manager &manager)
+{
+    return manager.register_backend(std::make_unique<mpi_communicator_backend>());
+}
 
 
 void mpi_communicator_backend::initialize() const

--- a/src/communication/mpi/mpi_communicator_backend.hpp
+++ b/src/communication/mpi/mpi_communicator_backend.hpp
@@ -69,7 +69,7 @@ public:
 private:
     mutable std::shared_ptr<mpi_instance> m_instance;
 
-    void initialize() const;
+    mpi_instance& get_instance() const;
 
 };
 

--- a/src/communication/mpi/mpi_communicator_backend.hpp
+++ b/src/communication/mpi/mpi_communicator_backend.hpp
@@ -41,6 +41,7 @@ namespace xmipp4
 namespace communication
 {
 
+class communicator_manager;
 class mpi_communicator;
 
 class mpi_communicator_backend final
@@ -62,6 +63,8 @@ public:
     bool is_available() const noexcept override;
     backend_priority get_priority() const noexcept override;
     std::shared_ptr<communicator> create_world_communicator() const override;
+
+    static bool register_at(communicator_manager &manager);
 
 private:
     mutable std::shared_ptr<mpi_instance> m_instance;

--- a/src/communication/mpi/mpi_communicator_backend.hpp
+++ b/src/communication/mpi/mpi_communicator_backend.hpp
@@ -47,7 +47,7 @@ class mpi_communicator_backend final
     : public communicator_backend
 {
 public:
-    mpi_communicator_backend();
+    mpi_communicator_backend() = default;
     mpi_communicator_backend(const mpi_communicator_backend &other) = default;
     mpi_communicator_backend(mpi_communicator_backend &&other) = default;
     ~mpi_communicator_backend() override = default;
@@ -64,7 +64,9 @@ public:
     std::shared_ptr<communicator> create_world_communicator() const override;
 
 private:
-    std::shared_ptr<mpi_instance> m_instance;
+    mutable std::shared_ptr<mpi_instance> m_instance;
+
+    void initialize() const;
 
 };
 

--- a/src/communication/mpi/mpi_instance.cpp
+++ b/src/communication/mpi/mpi_instance.cpp
@@ -28,6 +28,8 @@
 
 #include "mpi_instance.hpp"
 
+#include "mpi_error.hpp"
+
 #include <xmipp4/core/platform/assert.hpp>
 
 #include <mpi.h>
@@ -41,7 +43,8 @@ std::weak_ptr<mpi_instance> mpi_instance::m_singleton;
 
 mpi_instance::mpi_instance()
 {
-    MPI_Init(nullptr, nullptr);
+    const auto error = MPI_Init(nullptr, nullptr);
+    mpi_check_error(error);
 }
 
 mpi_instance::~mpi_instance()

--- a/src/communication/mpi/mpi_instance.cpp
+++ b/src/communication/mpi/mpi_instance.cpp
@@ -45,11 +45,19 @@ mpi_instance::mpi_instance()
 {
     const auto error = MPI_Init(nullptr, nullptr);
     mpi_check_error(error);
+    
+    m_world = std::make_shared<mpi_communicator>(MPI_COMM_WORLD);
 }
 
 mpi_instance::~mpi_instance()
 {
     MPI_Finalize();
+}
+
+const std::shared_ptr<mpi_communicator>& 
+mpi_instance::get_world_communicator() const noexcept
+{
+    return m_world;
 }
 
 std::shared_ptr<mpi_instance> mpi_instance::get()
@@ -65,6 +73,14 @@ std::shared_ptr<mpi_instance> mpi_instance::get()
     XMIPP4_ASSERT(result);
     return result;
 
+}
+
+version mpi_instance::get_mpi_version()
+{
+    int major = 0;
+    int minor = 0;
+    MPI_Get_version(&major, &minor); // Does not require initialization
+    return version(major, minor, 0);
 }
 
 } // namespace communication

--- a/src/communication/mpi/mpi_instance.hpp
+++ b/src/communication/mpi/mpi_instance.hpp
@@ -28,6 +28,10 @@
  * 
  */
 
+#include "mpi_communicator.hpp"
+
+#include <xmipp4/core/version.hpp>
+
 #include <memory>
 
 namespace xmipp4 
@@ -45,9 +49,14 @@ public:
     mpi_instance& operator=(const mpi_instance &other) = delete;
     mpi_instance& operator=(mpi_instance &&other) = delete;
 
+    const std::shared_ptr<mpi_communicator>& get_world_communicator() const noexcept;
+
     static std::shared_ptr<mpi_instance> get();
+    static version get_mpi_version();
 
 private:
+    std::shared_ptr<mpi_communicator> m_world;
+
     static std::weak_ptr<mpi_instance> m_singleton;
     
     mpi_instance();

--- a/src/communication/mpi/mpi_instance.hpp
+++ b/src/communication/mpi/mpi_instance.hpp
@@ -49,7 +49,8 @@ public:
     mpi_instance& operator=(const mpi_instance &other) = delete;
     mpi_instance& operator=(mpi_instance &&other) = delete;
 
-    const std::shared_ptr<mpi_communicator>& get_world_communicator() const noexcept;
+    const std::shared_ptr<mpi_communicator>& 
+    get_world_communicator() const noexcept;
 
     static std::shared_ptr<mpi_instance> get();
     static version get_mpi_version();

--- a/src/mpi_plugin.cpp
+++ b/src/mpi_plugin.cpp
@@ -56,9 +56,7 @@ void mpi_plugin::register_at(interface_registry& registry) const
     auto& communicator_manager = 
         registry.get_interface_manager<communication::communicator_manager>();
     
-    communicator_manager.register_backend(
-        std::make_unique<communication::mpi_communicator_backend>()
-    );
+    communication::mpi_communicator_backend::register_at(communicator_manager);
 }
 
 } // namespace xmipp4


### PR DESCRIPTION
In the old implementation, MPI was initialized when instantiating a `mpi_communicator_backend` which in turn is called when populating a `communicator_manager` in the plugin loading process. This may cause significant lag during initialization. By lazily initializing MPI, we intend to delay this lag to the moment where MPI is actually needed. 

Unfortunately, the current criteria to determine whether MPI is available (world size > 1) requires it to be initialized. Thus, this lag is unavoidable whenever a communicator is needed, even if MPI is not elected. In practice, when MPI is available, it will be the elected communicator.