### PR TITLE
Installing in bin/ in windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,9 +98,14 @@ if(MSVC)
 endif()
 
 # Install library's binary files and headers
+if(WIN32)
+    set(MODULE_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
+else()
+    set(MODULE_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+endif()
 install(
 	TARGETS ${PROJECT_NAME}
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/xmipp4-plugins/
+	LIBRARY DESTINATION ${MODULE_INSTALL_DIR}/xmipp4-plugins/
 )
 
 # Only build tests if it is the main project


### PR DESCRIPTION
In https://github.com/gigabit-clowns/xmipp4-binding-python/pull/25 we have observed that CMake `MODULE`-s get installed in `lib/` instead of `bin/` in Windows (our expected behavior). This PR conditionally installs to `bin/` in windows