### PR TITLE
Added deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy release
+
+on:
+  release:
+    types: 
+      - published
+  workflow_dispatch:
+
+jobs:
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    name: Upload to PyPI
+    needs: [build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -l ./dist
+
+      - name: Upload to PyPI
+        if: false && github.event_name == 'release' && github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@release/v1 # TODO enable this in the future

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ Homepage = "https://github.com/gigabit-clowns/xmipp4-communication-mpi"
 [tool.scikit-build]
 experimental=true # For wheel.install-dir
 wheel.install-dir="/data"
+wheel.py-api = "py3" # Python version agnostic
 cmake.version = ">=3.16"
 cmake.args = []
 cmake.verbose = false


### PR DESCRIPTION
Added deploy action. Not building wheels due to the variety of MPI flavors. Instead, only distributing an `sdist` package. Same as [mpi4py](https://github.com/mpi4py/mpi4py/blob/master/.github/workflows/dist.yml)